### PR TITLE
APP-316/z-index-fix

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -53,6 +53,7 @@
   top: 0;
   height: 100%;
   width: 100%;
+  z-index: var(--keyboard-zindex, @keyboard-zindex);
 
   &.is-visible .ML__keyboard--plate {
     transform: translate(
@@ -201,7 +202,6 @@
     left: 0;
     bottom: calc(-1 * var(--keyboard-height, @keyboard-height));
     width: 100%;
-    z-index: var(--keyboard-zindex, @keyboard-zindex);
 
     padding-top: 5px;
 


### PR DESCRIPTION
### [Issue Link](https://digiexam.atlassian.net/browse/APP-316)

# Description

Fix taken from mathlive v0.69.9.

# Tests

N/A

# QA:

**Note** that you might have to remove mathlive from package.json, then yarn, then add mathlive again, then yarn again for it to work. 

- [ ] Start an exam and make the Digiexam client window small enough that the mahlive virtual keyboard will cover the froala editor
- [ ] The mathlive virtual keyboard should be prioritized and cover everything behind it
